### PR TITLE
add Grunt support including ESLint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,32 @@
+{
+  "env": {
+    "node": true
+  },
+  "extends": "eslint:recommended",
+  "rules": {
+    "array-callback-return": "warn",
+    "brace-style": ["error", "1tbs"],
+    "complexity": ["warn", 20],
+    "eqeqeq": "error",
+    "guard-for-in": "error",
+    "indent": ["error", 2],
+    "linebreak-style": ["error", "unix"],
+    "no-array-constructor": "error",
+    "no-console": "warn",
+    "no-lonely-if": "warn",
+    "no-loop-func": "warn",
+    "no-mixed-spaces-and-tabs": ["error"],
+    "no-nested-ternary": "error",
+    "no-spaced-func": "error",
+    "no-trailing-spaces": "error",
+    "semi": ["error", "always"],
+    "space-before-blocks": "error",
+    "space-before-function-paren": ["error", "never"],
+    "keyword-spacing": ["error"],
+    "curly": ["error", "all"]
+  },
+  "globals": {
+    "angular": false,
+  }
+}
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
   - npm install -g grunt-cli
 install: npm install
 script:
+  - npm test
   - bash <(curl https://gist.githubusercontent.com/feedhenry-raincacher/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
 notifications:
   email: false

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,10 @@
+module.exports = function(grunt) {
+  'use strict';
+  grunt.initConfig({
+    eslint: {
+      src: ["lib/**/*.js"]
+    }
+  });
+  grunt.loadNpmTasks("grunt-eslint");
+  grunt.registerTask('default', ['eslint']);
+};

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,6 +5,7 @@ module.exports = function(grunt) {
       src: ["lib/**/*.js"]
     }
   });
+  grunt.loadTasks('tasks');
   grunt.loadNpmTasks("grunt-eslint");
   grunt.registerTask('default', ['eslint']);
 };

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A tool for building FeedHenry RainCatcher angular directive's templates.
 
-## Usage
+## Usage NPM
 
 Inside a RainCatcher Module, in the `package.json` add  :
 
@@ -27,3 +27,44 @@ Inside your module you can now watch for template changes :
 npm run watch  
 
 ```
+
+## Usage Grunt
+Add the dependency to your project using npm:
+
+    npm install --save-dev fh-wfm-template-build
+
+Load the plugin by adding it to your Gruntfile.js:
+
+    grunt.loadNpmTasks('fh-wfm-template-build');
+
+Add a configuration to your Gruntfile.js :
+
+    grunt.initConfig({
+      wfmTemplate: {
+        module: "wfm.<module-name>.directives",
+        templateDir: "lib/angular/template'
+      }
+    })
+
+There two target available to be run `build` and `watch`:
+
+    $ grunt wfmTemplate:build
+
+    $ grunt wfmTemplate:watch
+
+If you require different module names for `build` and `watch` you can add specific configurations
+for each target in `Gruntfile.js`. For example:
+
+      wfmTemplate: {
+        module: "wfm.<module-name>.directives",
+        templateDir: "lib/angular/template',
+        build: {
+          module: "some other module name",
+        }
+      }
+
+The module configuration `module` is an option you can also specify it on the command line like:
+
+    $ $ grunt wfm_watch --module=<module name>
+
+This will override any option specified in Gruntfile.js

--- a/lib/build.js
+++ b/lib/build.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var _ = require('lodash'),
-    fs = require('fs'),
-    html2js = require('ng-html2js');
+  fs = require('fs'),
+  html2js = require('ng-html2js');
 
 var templateDir = 'lib/angular/template';
 
@@ -15,7 +15,7 @@ function buildTemplates(moduleName) {
       console.error('Error reading files from', templateDir);
     }
     fs.mkdir('dist', '0775', function(err) {
-      if (err && err.code != 'EEXIST') {
+      if (err && err.code !== 'EEXIST') {
         console.log(err);
         throw new Error(err);
       }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 var argv = require('minimist')(process.argv.slice(2)),
-    build = require('./build'),
-    watch = require('node-watch');
+  build = require('./build'),
+  watch = require('node-watch');
 
 var moduleName;
 var watching = false;
@@ -19,7 +19,7 @@ if (argv.w || argv.watch) {
 if (moduleName) {
   build(moduleName);
   if (watching) {
-    watch('./' + templateDir, function(file) {
+    watch('./' + templateDir, function() {
       build(moduleName);
     });
   }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "bin": {
     "wfm-template-build": "./lib/cli.js"
   },
+  "scripts": {
+    "test": "grunt"
+  },
   "main": "lib/build.js",
   "keywords": [
     "wfm",
@@ -17,5 +20,9 @@
     "minimist": "1.2.0",
     "ng-html2js": "2.0.0",
     "node-watch": "0.3.5"
+  },
+  "devDependencies": {
+    "grunt": "^1.0.1",
+    "grunt-eslint": "^18.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-template-build",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "description": "A build tool for WFM modules",
   "bin": {
     "wfm-template-build": "./lib/cli.js"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "main": "lib/build.js",
   "keywords": [
     "wfm",
-    "build"
+    "build",
+    "gruntplugin"
   ],
   "author": "Brian Leathem",
   "license": "MIT",

--- a/tasks/wfm_build.js
+++ b/tasks/wfm_build.js
@@ -1,0 +1,43 @@
+'use strict';
+
+let build = require('../lib/build.js');
+let watch = require('node-watch');
+const taskName = 'wfmTemplate';
+
+module.exports = function(grunt) {
+
+  grunt.config.merge({
+    wfmTemplate: {
+      build: {},
+      watch: {}
+    }
+  });
+
+  grunt.registerMultiTask('wfmTemplate', 'A build tool for WFM modules', function() {
+    const taskConfig = grunt.config.get(this.name);
+    const moduleName = getAndCheckModuleName(this, grunt, taskConfig);
+    this.async();
+
+    if (this.target === 'build') {
+      build(moduleName);
+    } else if (this.target === 'watch') {
+      watch('./' + taskConfig.templateDir || 'lib/angular/template', () => build(templateDir));
+    } else {
+      usage(grunt, this.name);
+    }
+  });
+
+};
+
+function getAndCheckModuleName(task, grunt, taskConfig) {
+  let moduleName = grunt.option('module') || task.data.module || taskConfig.module;
+  grunt.log.debug("--module=" + moduleName);
+  if (!moduleName) {
+    usage(grunt, task.name);
+  }
+  return moduleName;
+};
+
+function usage(grunt, taskName) {
+  grunt.fail.fatal('Usage: ' + taskName + ':[build | watch] --module=<module name> \nOptions:\n  --module=<module name> If module name is provided, template will be packaged under this module.\n\n');
+}


### PR DESCRIPTION
Motivation:
The goal of this task is to add grunt tasks to this project. The first
step is adding Grunt support.

Modifications:
Added Grunt and ESLint support and also enabled ESLint to be run as part
of Travis CI.

JIRA:
https://issues.jboss.org/browse/RAINCATCH-187
