### PR TITLE
Add repository URL to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     "test": "grunt"
   },
   "main": "lib/build.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/feedhenry-raincatcher/raincatcher-template-build.git"
+  },
   "keywords": [
     "wfm",
     "build",


### PR DESCRIPTION
Prevents warning during `npm install`.